### PR TITLE
Fix variable to be compared uninitialized

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -437,7 +437,7 @@ public:
         // Immediate operand
         if (opcode <= OP_PUSHDATA4)
         {
-            unsigned int nSize;
+            unsigned int nSize = 0;
             if (opcode < OP_PUSHDATA1)
             {
                 nSize = opcode;


### PR DESCRIPTION
nSize could be compared in an uninitialized state below. So initialize it
to zero, to be safe.