### PR TITLE
Add error checks for issues in glue.c

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -51,7 +51,9 @@ int8_t portable_spawn(char *os, char *cmd, char *arg) //TODO: extend for other O
         strcat(cmdArgs, arg);
 	    pid_t pid = 0;
 	    pid = fork();
-	    if (pid==0)//child process
+	    if (pid == -1)
+		status = 1;
+	    else if (pid==0)//child process
 	    {
             if ( system(cmd) != 0 )
                 status = 1;

--- a/src/glue.c
+++ b/src/glue.c
@@ -32,7 +32,9 @@ int8_t portable_spawn(char *os, char *cmd, char *arg) //TODO: extend for other O
 #ifndef _WIN32
         pid_t pid = 0;
         pid = fork();
-        if ( pid == 0 ) //child process
+	if (pid == -1)
+		status = 1;
+	else if ( pid == 0 ) //child process
         {
             if ( execl(cmd, arg, NULL) )
 		        status = 1;

--- a/src/glue.c
+++ b/src/glue.c
@@ -46,6 +46,9 @@ int8_t portable_spawn(char *os, char *cmd, char *arg) //TODO: extend for other O
     {
 #ifndef _WIN32
         char *cmdArgs = (char*)malloc(strlen(cmd)+strlen(arg)+16);
+        if (!cmdArgs)
+	    return 1;		// Direct error return, we're toast
+
         strcpy(cmdArgs, cmd);
         strcat(cmdArgs, " ");
         strcat(cmdArgs, arg);


### PR DESCRIPTION
Two fork() calls' and a malloc() call's return values were not being checking possibly resulting in erroneous operation.  This branchs fixes these issues, one commit for each fix.